### PR TITLE
feat: catch SIGPIPE via no-op handler (logs to debug)

### DIFF
--- a/src/app.hpp
+++ b/src/app.hpp
@@ -20,6 +20,7 @@
 #include "http/server.hpp"
 #include "views/domains.hpp"
 #include "views/host.hpp"
+#include "virt/connection_pool.hpp"
 #include <regex>
 
 namespace webvirt
@@ -36,9 +37,13 @@ private:
     views::host host_view_;
     views::domains domains_view_;
 
+    virt::connection_pool pool_;
+
 public:
     app(webvirt::io_service &io, const std::filesystem::path &socket_path);
     std::size_t run();
+
+    virt::connection_pool &pool();
 
 private:
     template <typename Func>

--- a/src/bench.hpp
+++ b/src/bench.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#ifndef BENCH_HPP
+#define BENCH_HPP
+
+#include <chrono>
+
+namespace webvirt
+{
+
+template <typename value_type>
+class bench
+{
+private:
+    std::chrono::high_resolution_clock clock_;
+    std::chrono::high_resolution_clock::time_point start_;
+    std::chrono::high_resolution_clock::time_point end_;
+
+public:
+    bench()
+    {
+        start();
+    }
+
+    value_type elapsed() const
+    {
+        return std::chrono::duration<value_type>(end_ - start_).count();
+    }
+
+    void start()
+    {
+        start_ = clock_.now();
+    }
+
+    value_type end()
+    {
+        end_ = clock_.now();
+        return elapsed();
+    }
+};
+
+}; // namespace webvirt
+
+#endif /* BENCH_HPP */

--- a/src/http/client.hpp
+++ b/src/http/client.hpp
@@ -148,7 +148,9 @@ public:
 
     std::size_t run()
     {
-        return io_.process();
+        std::size_t count = io_.process();
+        close();
+        return count;
     }
 
 private:
@@ -164,6 +166,7 @@ private:
 
     void async_connect()
     {
+        io_.reset();
         socket_.async_connect(socket_path_,
                               boost::beast::bind_front_handler(
                                   &client<protocol_t>::client_async_on_connect,

--- a/src/http/connection.hpp
+++ b/src/http/connection.hpp
@@ -115,8 +115,11 @@ private:
     void process_request()
     {
         logger::debug([this] {
-            const char *method = request_.method_string().data();
-            const char *target = request_.target().data();
+            const std::string method =
+                std::string(request_.method_string().data(),
+                            request_.method_string().size());
+            const std::string target = std::string(request_.target().data(),
+                                                   request_.target().size());
             return fmt::format(
                 "Received \"{} {} HTTP/{}.{}\"",
                 method,

--- a/src/http/middleware.hpp
+++ b/src/http/middleware.hpp
@@ -17,6 +17,7 @@
 #define HTTP_MIDDLEWARE_HPP
 
 #include "../virt/connection.hpp"
+#include "../virt/connection_pool.hpp"
 #include "../virt/domain.hpp"
 #include "namespaces.hpp"
 #include <regex>
@@ -30,13 +31,15 @@ route_function with_methods(const std::vector<boost::beast::http::verb> &,
                             route_function);
 
 route_function with_libvirt_domain(
+    virt::connection_pool &pool,
     std::function<void(virt::connection &, virt::domain domain,
                        const std::smatch &, const http::request &,
                        http::response &)>);
 
 route_function
-    with_libvirt(std::function<void(virt::connection &, const std::smatch &,
-                                    const http::request &, http::response &)>);
+with_libvirt(virt::connection_pool &,
+             std::function<void(virt::connection &, const std::smatch &,
+                                const http::request &, http::response &)>);
 
 route_function
     with_user(std::function<void(const std::smatch &, const http::request &,

--- a/src/libvirt.cpp
+++ b/src/libvirt.cpp
@@ -71,6 +71,13 @@ libvirt::connect_ptr libvirt::virConnectOpen(const char *uri)
     return connect_ptr(::virConnectOpen(uri), free_connect_ptr());
 }
 
+int libvirt::virConnectRegisterCloseCallback(
+    connect_ptr conn, void (*fn)(connect *, int, void *), void *data,
+    void (*free_data)(void *))
+{
+    return ::virConnectRegisterCloseCallback(conn.get(), fn, data, free_data);
+}
+
 std::string libvirt::virConnectGetCapabilities(connect_ptr conn)
 {
     return from_c_string(::virConnectGetCapabilities(conn.get()));

--- a/src/libvirt.hpp
+++ b/src/libvirt.hpp
@@ -20,6 +20,7 @@
 #ifdef TEST_BUILD
 #include "stubs/libvirt.hpp"
 #endif
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -62,6 +63,10 @@ public:
 
     // virConnect
     virtual connect_ptr virConnectOpen(const char *);
+    virtual int virConnectRegisterCloseCallback(connect_ptr,
+                                                void (*)(connect *, int,
+                                                         void *),
+                                                void *, void (*)(void *));
 
     virtual std::string virConnectGetCapabilities(connect_ptr);
     virtual std::string virConnectGetHostname(connect_ptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "http/connection.hpp"
 #include "http/io_service.hpp"
 #include "http/server.hpp"
+#include "signal.hpp"
 #include "syscaller.hpp"
 #include <boost/program_options/errors.hpp>
 #include <filesystem>
@@ -105,6 +106,8 @@ int main(int argc, const char *argv[])
                         ->default_value(15.0)
                         ->multitoken(),
                     "timeout in seconds for domain shutoff state to react");
+
+    signal(SIGPIPE, webvirt::signal::pipe);
 
     try {
         conf.parse(argc, argv);

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ sources = [
   'views/host.cpp',
   'virt/network.cpp',
   'virt/domain.cpp',
+  'virt/connection_pool.cpp',
   'virt/connection.cpp',
   'virt/util.cpp',
   'http/router.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ sources = [
   'json.cpp',
   'config.cpp',
   'libvirt.cpp',
+  'signal.cpp',
   'logging.cpp',
   'views/domains.cpp',
   'views/host.cpp',
@@ -118,6 +119,14 @@ if not get_option('disable_tests')
     cpp_args : flags + test_flags,
   )
   test('logging test', logging_test)
+
+  signal_test = executable(
+    'signal.test',
+    'signal.test.cpp',
+    dependencies : test_deps,
+    cpp_args : flags + test_flags,
+  )
+  test('signal test', signal_test)
 endif
 
 subdir('http')

--- a/src/mocks/libvirt.hpp
+++ b/src/mocks/libvirt.hpp
@@ -28,6 +28,9 @@ public:
     ~libvirt() = default;
 
     MOCK_METHOD(connect_ptr, virConnectOpen, (const char *));
+    MOCK_METHOD(int, virConnectRegisterCloseCallback,
+                (connect_ptr, void (*)(webvirt::connect *, int, void *),
+                 void *, void (*)(void *)));
 
     MOCK_METHOD(std::string, virConnectGetCapabilities, (connect_ptr));
     MOCK_METHOD(std::string, virConnectGetHostname, (connect_ptr));

--- a/src/retry.hpp
+++ b/src/retry.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#ifndef RETRY_HPP
+#define RETRY_HPP
+
+#include <functional>
+#include <stdexcept>
+
+namespace webvirt
+{
+struct retry_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+template <typename exception = retry_error,
+          typename fatal_exception = std::domain_error>
+class retry
+{
+private:
+    unsigned int retries_ { 1 };
+    unsigned int retry_ { 0 };
+    std::function<void()> func_;
+
+public:
+    retry(std::function<void()> func)
+        : func_(func)
+    {
+    }
+
+    retry &retries(unsigned int n)
+    {
+        retries_ = n;
+        return *this;
+    }
+
+    void operator()()
+    {
+        try {
+            func_();
+        } catch (const exception &exc) {
+            if (retry_++ < retries_) {
+                operator()();
+            } else {
+                throw fatal_exception(exc.what());
+            }
+        }
+    }
+};
+
+}; // namespace webvirt
+
+#endif /* RETRY_HPP */

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "signal.hpp"
+#include "logging.hpp"
+using namespace webvirt;
+
+void signal::pipe(int)
+{
+    logger::debug("Caught SIGPIPE");
+}

--- a/src/signal.hpp
+++ b/src/signal.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#ifndef SIGNAL_HPP
+#define SIGNAL_HPP
+
+namespace webvirt::signal
+{
+
+void pipe(int);
+
+};
+
+#endif /* SIGNAL_HPP */

--- a/src/signal.test.cpp
+++ b/src/signal.test.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "signal.hpp"
+#include "logging.hpp"
+#include <gtest/gtest.h>
+using namespace webvirt;
+
+using testing::Test;
+
+class signal_test : public Test
+{
+public:
+    void SetUp() override
+    {
+        logger::enable_debug(true);
+    }
+
+    void TearDown() override
+    {
+        logger::reset_debug();
+    }
+};
+
+TEST_F(signal_test, sigpipe)
+{
+    testing::internal::CaptureStdout();
+    signal::pipe(SIGPIPE);
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(output.find("Caught SIGPIPE"), std::string::npos);
+}

--- a/src/stubs/libvirt.cpp
+++ b/src/stubs/libvirt.cpp
@@ -30,6 +30,13 @@ connect *virConnectOpen(const char *)
     return nullptr;
 }
 
+int virConnectRegisterCloseCallback(webvirt::connect *,
+                                    void (*)(webvirt::connect *, int, void *),
+                                    void *, void (*)(void *))
+{
+    return 0;
+}
+
 char *virConnectGetCapabilities(webvirt::connect *)
 {
     return make_cstring("");

--- a/src/stubs/libvirt.hpp
+++ b/src/stubs/libvirt.hpp
@@ -38,7 +38,9 @@ enum metadataType : int {
 
 // virConnect
 webvirt::connect *virConnectOpen(const char *);
-
+int virConnectRegisterCloseCallback(webvirt::connect *,
+                                    void (*)(webvirt::connect *, int, void *),
+                                    void *, void (*)(void *));
 char *virConnectGetCapabilities(webvirt::connect *);
 char *virConnectGetHostname(webvirt::connect *);
 int virConnectGetLibVersion(webvirt::connect *, unsigned long *);

--- a/src/virt/connection.hpp
+++ b/src/virt/connection.hpp
@@ -20,6 +20,7 @@
 #include "../logging.hpp"
 #include "domain.hpp"
 #include "network.hpp"
+#include <atomic>
 #include <cstring>
 #include <errno.h>
 #include <json/json.h>
@@ -35,9 +36,16 @@ namespace webvirt::virt
 class connection
 {
 private:
-    libvirt::connect_ptr conn_ = nullptr;
-    int errno_ = 0;
-    logger log_;
+    libvirt::connect_ptr conn_ { nullptr };
+    int errno_ { 0 };
+    bool closed_ { true };
+
+public:
+#ifdef TEST_BUILD
+    bool &closed();
+#else
+    bool closed();
+#endif
 
 public:
     connection() = default;
@@ -45,8 +53,10 @@ public:
     connection(const std::string &uri);
 
     connection &operator=(const connection &conn);
+    operator bool();
     bool operator==(const connection &other) const;
     bool operator!=(const connection &other) const;
+
     connection &connect(const std::string &str);
 
     std::string capabilities() const;

--- a/src/virt/connection_pool.cpp
+++ b/src/virt/connection_pool.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "connection_pool.hpp"
+#include "../bench.hpp"
+#include "../logging.hpp"
+#include "util.hpp"
+using namespace webvirt::virt;
+
+connection &connection_pool::get(const std::string &user)
+{
+    bench<double> bench_;
+
+    auto iter = connections_.find(user);
+    if (iter == connections_.end()) {
+        connections_[user] = virt::connection();
+        connections_[user].connect(virt::uri(user));
+        auto ms = bench_.end() * 1000;
+        logger::debug(fmt::format("Connected to libvirt in {}ms", int(ms)));
+        return connections_.at(user);
+    }
+
+    if (!iter->second) {
+        // If connection is stale, try reconnecting.
+        iter->second = virt::connection();
+        iter->second.connect(virt::uri(user));
+        auto ms = bench_.end() * 1000;
+        logger::debug(fmt::format("Reconnected to libvirt in {}ms", int(ms)));
+    }
+
+    return iter->second;
+}

--- a/src/virt/connection_pool.hpp
+++ b/src/virt/connection_pool.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Kevin Morris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#ifndef VIRT_CONNECTION_POOL_HPP
+#define VIRT_CONNECTION_POOL_HPP
+
+#include "connection.hpp"
+#include <map>
+#include <string>
+
+namespace webvirt::virt
+{
+
+class connection_pool
+{
+private:
+    // username -> connection
+    std::map<std::string, connection> connections_;
+
+public:
+    connection &get(const std::string &);
+};
+
+}; // namespace webvirt::virt
+
+#endif /* VIRT_CONNECTION_POOL_HPP */

--- a/src/virt/domain.cpp
+++ b/src/virt/domain.cpp
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */
 #include "domain.hpp"
+#include "../bench.hpp"
 #include "../config.hpp"
 #include "../logging.hpp"
 #include "util.hpp"
@@ -77,11 +78,9 @@ std::string virt::domain::description() const
 
 std::string virt::domain::xml_desc()
 {
-    std::chrono::high_resolution_clock clock;
-    std::chrono::high_resolution_clock::time_point start = clock.now();
+    bench<double> bench_;
     auto desc = libvirt::ref().virDomainGetXMLDesc(ptr_, 0);
-    std::chrono::high_resolution_clock::time_point end = clock.now();
-    auto elapsed = std::chrono::duration<double>(end - start).count() * 1000;
+    double elapsed = bench_.end() * 1000;
     logger::debug(
         fmt::format("Producing XML description took {:.2f}ms", elapsed));
     return desc;


### PR DESCRIPTION
SIGPIPE is sent to the process when libvirt attempts to write to a dead socket.

We catch SIGPIPE here, because we want to maintain control over the application runtime when this occurs -- it simply signals to us that our libvirt connection died and must be re-established.